### PR TITLE
Remove outdated guidance re Node.js from requirements-and-dependencie…

### DIFF
--- a/docs/installing/requirements-and-dependencies.rst
+++ b/docs/installing/requirements-and-dependencies.rst
@@ -41,7 +41,6 @@ Arches requires the following software packages to be installed and available. U
 :GEOS >= 3.8:
     - See the above GDAL installation instructions above for Windows and macOS
 :Node.js 20.14.x (recommended): - Installation: https://nodejs.org/ (choose the installer appropriate to your operating system).
-    - NOTE: Arches may not be compatible with later versions of Node.js (after 16) `(see discussion) <https://community.archesproject.org/t/newbie-v7-install-experience-some-hints-and-tips/1782>`_.
 
 To support long-running task management, like large user downloads, you must install a Celery broker like RabbitMQ or Redis:
 


### PR DESCRIPTION
…s.rst

Removed outdated guidance wrt Node.js as per forum post at:

  https://community.archesproject.org/t/ignorant-questions-about-node-js-and-npm/2994/3

### brief description of changes
<!-- please describe the changes here -->

Delete outdated line about compatibility of Node.js with Arches on the basis of advice from @chrabyrd in forum post.

---

This box **must** be checked
- [X] the PR branch was originally made from the base branch

This box **should** be checked
- [X ] after these changes the docs build locally without error

This box **should only** be checked you intend to follow through on it (we can do it on our end too)
- [ ] I will `cherry-pick` all commits in this PR into other branches that should have them _after_ this PR is merged
